### PR TITLE
Update paper

### DIFF
--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -32,11 +32,10 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: paper
+          name: paper-${{ github.sha }}  # Make artifact name unique
           # This is the output path where Pandoc will write the compiled
           # PDF. Note, this should be the same directory as the input
           # paper.md
-          name: paper-${{ github.sha }}  # Make artifact name unique
           path: paper.pdf
       - name: Commit PDF to repository
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/draft-pdf.yml
+++ b/.github/workflows/draft-pdf.yml
@@ -1,10 +1,20 @@
 name: Draft PDF
 on:
   push:
+    branches:
+      - main
+      - update-paper
     paths:
-      - paper.md
-      - paper.bib
-      - .github/workflows/draft-pdf.yml
+      - 'paper.md'
+      - 'paper.bib'
+      - '.github/workflows/draft-pdf.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'paper.md'
+      - 'paper.bib'
+      - '.github/workflows/draft-pdf.yml'
 
 jobs:
   paper:
@@ -19,15 +29,17 @@ jobs:
           journal: joss
           # This should be the path to the paper within your repo.
           paper-path: paper.md
-      - name: Upload
+      - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: paper
           # This is the output path where Pandoc will write the compiled
           # PDF. Note, this should be the same directory as the input
           # paper.md
+          name: paper-${{ github.sha }}  # Make artifact name unique
           path: paper.pdf
       - name: Commit PDF to repository
+        if: github.ref == 'refs/heads/main'
         uses: EndBug/add-and-commit@v9
         with:
           message: '(auto) Paper PDF Draft'

--- a/paper.md
+++ b/paper.md
@@ -70,15 +70,14 @@ any arbitrary irradiation schedule from any radiation source.
 The package presented here automates the time-consuming task of extracting the 
 numerical results and metadata from PHITS/DCHAIN simulations and organizes them into 
 a standardized format, easing and expediting further practical real-world analyses. 
-It also can automatically produce images of plotted tally outputs and 
-provides functions for some of the most common analyses one 
+It also provides functions for some of the most common analyses one 
 may wish to perform on simulation outputs.
 
 
 
 # Statement of need
 
-`PHITS Tools` (and its `DCHAIN Tools` submodule) serve as an interface between the plaintext (and binary) outputs
+`PHITS Tools` and its `DCHAIN Tools` submodule serve as an interface between the plaintext (and binary) outputs
 of the PHITS and DCHAIN codes and Python&mdash;greatly expediting further programmatic analyses, 
 comparisons, and visualization&mdash;and provide some extra analysis tools. 
 The outputs of the PHITS code are, aside from the special binary "dump" files, plaintext files formatted 
@@ -90,7 +89,8 @@ writing a bespoke processing script for most individual simulations,
 possibly preceded by manual data extraction/isolation too. 
 `PHITS Tools` provides universal output parsers for the PHITS and DCHAIN codes, 
 capable of processing all of the relevant output files produced by each code and
-outputting the numerical results and metadata in a consistent, standardized output format.
+outputting the numerical results and metadata in a consistent, standardized output format, 
+along with the ability to automatically produce images of plotted tally outputs too.
 
 The substantial number of combinations within PHITS of geometry specification, 
 scoring axes (spatial, energy, time, angle, LET, etc.), tally types (scoring volumetric and surface crossing 

--- a/paper.md
+++ b/paper.md
@@ -100,7 +100,7 @@ highlight the utility of such a universal processing code for PHITS.
 When parsing standard PHITS tally output, `PHITS Tools` returns a metadata dictionary, 
 a 10-dimensional NumPy array universally accommodating of all possible PHITS tally output
 containing all numerical results (structured as shown in the table below), and 
-a Pandas DataFrame containing the same numerical information for users preferring Pandas.
+a Pandas DataFrame containing the same numerical information for users preferring working with Pandas.
 
 +------------+---------------------------------------------------------------------------------------+
 | axis       | description                                                                           |
@@ -131,14 +131,14 @@ a Pandas DataFrame containing the same numerical information for users preferrin
 `PHITS Tools` is also capable of parsing the "dump" output files (both binary and ASCII formats) 
 that are available for some tallies, and it can also automatically detect, parse, and process all PHITS 
 output files listed within a provided directory or PHITS input file, very convenient 
-for PHITS simulations employing multiple tallies, each with its own output file, 
+for simulations employing multiple tallies, each with its own output file, 
 whose output are to be further studied, e.g., compared to experimental data or other simulations. 
 The `PHITS Tools` module can be used by 
 (1) importing it as a Python module in a script and calling its functions, 
 (2) running it in the command line via its CLI with a provided PHITS output
- file (or directory of files) and settings flags/options, or 
+ file (or directory/input) and settings flags/options, or 
 (3) running it without any arguments to launch a GUI stepping the user through 
-the various output processing options and settings within `PHITS Tools`.
+the various output processing options and settings in `PHITS Tools`.
 
 When used as an imported module, `PHITS Tools` provides a number of supplemental
 functions aiding with further analyses, such as tools for 

--- a/paper.md
+++ b/paper.md
@@ -90,18 +90,17 @@ possibly preceded by manual data extraction/isolation too.
 `PHITS Tools` provides universal output parsers for the PHITS and DCHAIN codes, 
 capable of processing all of the relevant output files produced by each code and
 outputting the numerical results and metadata in a consistent, standardized output format, 
-along with the ability to automatically produce images of plotted tally outputs too.
+also able to automatically make and save plots (PNG/PDF) of tally results too.
 
 The substantial number of combinations within PHITS of geometry specification, 
 scoring axes (spatial, energy, time, angle, LET, etc.), tally types (scoring volumetric and surface crossing 
 particle fluxes, energy deposition, nuclide production, interactions,  DPA, and more), potential 
-particle species, and fair amount of "exceptions" or "edge cases" related to specific tallies and/or their settings 
+particle species, and fair amount of exceptions/edge cases related to specific tallies and/or their settings 
 highlight the utility of such a universal processing code for PHITS. 
-When parsing standard PHITS tally output, `PHITS Tools` will return a metadata dictionary, 
+When parsing standard PHITS tally output, `PHITS Tools` returns a metadata dictionary, 
 a 10-dimensional NumPy array universally accommodating of all possible PHITS tally output
 containing all numerical results (structured as shown in the table below), and 
-a Pandas DataFrame containing the same numerical information, which
-may be more user-friendly to those accustomed to working in Pandas.
+a Pandas DataFrame containing the same numerical information for users preferring Pandas.
 
 +------------+---------------------------------------------------------------------------------------+
 | axis       | description                                                                           |
@@ -131,7 +130,7 @@ may be more user-friendly to those accustomed to working in Pandas.
 
 `PHITS Tools` is also capable of parsing the "dump" output files (both binary and ASCII formats) 
 that are available for some tallies, and it can also automatically detect, parse, and process all PHITS 
-output files within a provided directory or produced by a specified PHITS input file, very convenient 
+output files listed within a provided directory or PHITS input file, very convenient 
 for PHITS simulations employing multiple tallies, each with its own output file, 
 whose output are to be further studied, e.g., compared to experimental data or other simulations. 
 The `PHITS Tools` module can be used by 

--- a/paper.md
+++ b/paper.md
@@ -1,5 +1,5 @@
 ---
-title: 'PHITS & DCHAIN Tools: Python modules for parsing, organizing, and analyzing results from the PHITS radiation transport and DCHAIN activation codes'
+title: 'The PHITS Tools Python package for parsing, organizing, and analyzing results from the PHITS radiation transport and DCHAIN activation codes'
 tags:
   - PHITS
   - DCHAIN
@@ -67,17 +67,18 @@ The DCHAIN code coupled to PHITS specializes in calculating nuclide inventories 
 (such as activity, decay heat, decay gamma-ray emission spectra, and more) as a function of time for 
 any arbitrary irradiation schedule from any radiation source.
 
-The modules presented here automate the time-consuming task of extracting the 
+The package presented here automates the time-consuming task of extracting the 
 numerical results and metadata from PHITS/DCHAIN simulations and organizes them into 
 a standardized format, easing and expediting further practical real-world analyses. 
-They also provide functions for some of the most common analyses one 
+It also can automatically produce images of plotted tally outputs and 
+provides functions for some of the most common analyses one 
 may wish to perform on simulation outputs.
 
 
 
 # Statement of need
 
-`PHITS Tools` and `DCHAIN Tools` serve as an interface between the plaintext (and binary) outputs
+`PHITS Tools` (and its `DCHAIN Tools` submodule) serve as an interface between the plaintext (and binary) outputs
 of the PHITS and DCHAIN codes and Python&mdash;greatly expediting further programmatic analyses, 
 comparisons, and visualization&mdash;and provide some extra analysis tools. 
 The outputs of the PHITS code are, aside from the special binary "dump" files, plaintext files formatted 
@@ -87,7 +88,7 @@ code are formatted in a variety of tabular, human-readable structures.  Historic
 extraction and organization of numerical results and metadata from both codes often required 
 writing a bespoke processing script for most individual simulations, 
 possibly preceded by manual data extraction/isolation too. 
-`PHITS Tools` and `DCHAIN Tools` provide universal output parsers for the PHITS and DCHAIN codes, 
+`PHITS Tools` provides universal output parsers for the PHITS and DCHAIN codes, 
 capable of processing all of the relevant output files produced by each code and
 outputting the numerical results and metadata in a consistent, standardized output format.
 
@@ -130,9 +131,9 @@ may be more user-friendly to those accustomed to working in Pandas.
 
 `PHITS Tools` is also capable of parsing the "dump" output files (both binary and ASCII formats) 
 that are available for some tallies, and it can also automatically detect, parse, and process all PHITS 
-output files within a provided directory, very convenient for PHITS simulations employing 
-multiple tallies, each with its own output file, whose output are to be further studied, 
-e.g., compared to experimental data or other simulations. 
+output files within a provided directory or produced by a specified PHITS input file, very convenient 
+for PHITS simulations employing multiple tallies, each with its own output file, 
+whose output are to be further studied, e.g., compared to experimental data or other simulations. 
 The `PHITS Tools` module can be used by 
 (1) importing it as a Python module in a script and calling its functions, 
 (2) running it in the command line via its CLI with a provided PHITS output
@@ -141,23 +142,23 @@ The `PHITS Tools` module can be used by
 the various output processing options and settings within `PHITS Tools`.
 
 When used as an imported module, `PHITS Tools` provides a number of supplemental
-functions aiding with further analyses, such as tools for constructing one's own 
-tally over the history-by-history output of the "dump" files, rebinning histogrammed 
-results to a different desired binning structure, applying effective dose 
-conversion coefficients from ICRP 116 [@ICRP116_ref_withauthors] to tallied particle 
-fluences, or retrieving a PHITS-input-formatted [Material] section entry (including 
+functions aiding with further analyses, such as tools for 
+constructing one's own tally over the history-by-history output of the "dump" files, 
+rebinning histogrammed results to a different desired binning structure, 
+applying effective dose conversion coefficients from ICRP 116 [@ICRP116_ref_withauthors] 
+to tallied particle fluences, or 
+retrieving a PHITS-input-formatted [Material] section entry (including 
 its corresponding density) from a large database of over 350 materials (primarily
 consisting of the selection of materials within the PNNL Compendium of Material 
 Composition Data for Radiation Transport Modeling [@PNNL_materials_compendium]),
 among other useful functions.
 
-`DCHAIN Tools` is a separate Python module for handling the outputs of the DCHAIN code and 
-is included as a submodule within the `PHITS Tools` repository.  Its primary function 
+The `DCHAIN Tools` submodule handles the outputs of the DCHAIN code.  Its primary function 
 parses all of the various output files of the DCHAIN code and compiles the metadata
 and numeric results&mdash;the confluence of the specified regions, output time steps, 
 all nuclides and their inventories (and derived quantities), and complex decay chain 
 schemes illustrating the production/destruction mechanisms for all nuclides&mdash;into 
-a single unified dictionary object.  The `DCHAIN Tools` module includes some additional
+a single unified dictionary object.  The `DCHAIN Tools` submodule includes some additional
 useful functions such as retrieving neutron activation cross sections from DCHAIN's built-in 
 nuclear data libraries, calculating flux-weighted single-group activation cross sections, 
 and visualizing and summarizing the most significant nuclides (in terms of activity, 
@@ -165,7 +166,7 @@ decay heat, or gamma-ray dose) as a function of time. If `PHITS Tools` is provid
 files, `DCHAIN Tools` will be automatically imported and its primary function executed
 on the DCHAIN output.
 
-In all, the `PHITS Tools` and `DCHAIN Tools` modules make the results produced by the PHITS and DCHAIN codes 
+In all, the `PHITS Tools` package makes the results produced by the PHITS and DCHAIN codes 
 far more accessible for further use, analyses, comparisons, and visualizations in 
 Python, removing the initial hurdle of parsing and organizing the raw output from these codes, 
 and provides some additional tools for easing further analyses and drawing conclusions from 

--- a/paper.md
+++ b/paper.md
@@ -130,17 +130,17 @@ a Pandas DataFrame containing the same numerical information for users preferrin
 
 `PHITS Tools` is also capable of parsing the "dump" output files (both binary and ASCII formats) 
 that are available for some tallies, and it can also automatically detect, parse, and process all PHITS 
-output files listed within a provided directory or PHITS input file, very convenient 
+output files listed in a provided directory or PHITS input file, very convenient 
 for simulations employing multiple tallies, each with its own output file, 
 whose output are to be further studied, e.g., compared to experimental data or other simulations. 
-The `PHITS Tools` module can be used by 
-(1) importing it as a Python module in a script and calling its functions, 
+`PHITS Tools` can be used by 
+(1) importing it as a Python package in a script and calling its functions, 
 (2) running it in the command line via its CLI with a provided PHITS output
  file (or directory/input) and settings flags/options, or 
 (3) running it without any arguments to launch a GUI stepping the user through 
 the various output processing options and settings in `PHITS Tools`.
 
-When used as an imported module, `PHITS Tools` provides a number of supplemental
+When used as an imported package, `PHITS Tools` provides a number of supplemental
 functions aiding with further analyses, such as tools for 
 constructing one's own tally over the history-by-history output of the "dump" files, 
 rebinning histogrammed results to a different desired binning structure, 

--- a/paper.md
+++ b/paper.md
@@ -136,7 +136,7 @@ whose output are to be further studied, e.g., compared to experimental data or o
 `PHITS Tools` can be used by 
 (1) importing it as a Python package in a script and calling its functions, 
 (2) running it in the command line via its CLI with a provided PHITS output
- file (or directory/input) and settings flags/options, or 
+ file (or directory/input file) path and settings flags/options, or 
 (3) running it without any arguments to launch a GUI stepping the user through 
 the various output processing options and settings in `PHITS Tools`.
 


### PR DESCRIPTION
This PR makes some updates to the JOSS paper reflecting some of the progress on PHITS Tools over the past months.  Most of these are small wording changes (namely, referring to PHITS Tools as a "package" rather than a "module"), more accurately reflecting DCHAIN Tools's status as a submodule (rather than co-module) to PHITS Tools, and adding some small text about additional functionalities implemented (automatic plot generation, scanning PHITS input files for output files to be parsed).  Perhaps most significantly, the title of the paper is now changed to _"The PHITS Tools Python package for parsing, organizing, and analyzing results from the PHITS radiation transport and DCHAIN activation codes"_.

Furthermore, it also updates the GitHub Actions workflow used for generating a draft PDF from the `paper.md` file to allow for a more sensible workflow for editing the paper from within the `update-paper` branch (not pushing the PDF to the repo every time, just making the paper PDF artifact available to download and preview).