### PR TITLE
fix refs, minor grammar

### DIFF
--- a/paper.bib
+++ b/paper.bib
@@ -9,7 +9,7 @@
   url       = {https://doi.org/10.1080/00223131.2023.2275736},
   journal   = {Journal of Nuclear Science and Technology},
   publisher = {Taylor \& Francis},
-  year      = {2024},
+  year      = {2023},
 }
 
 @Article{DCHAIN_ref,
@@ -56,7 +56,7 @@
 @TechReport{PNNL_materials_compendium,
   author      = {McConn, Ronald J and Gesh, Christopher J and Pagh, Richard T and Rucker, Robert A and Williams, III, Robert},
   institution = {Pacific Northwest National Lab. (PNNL), Richland, WA (United States)},
-  title       = {Compendium of Material Composition Data for Radiation Transport Modeling},
+  title       = {{Compendium of Material Composition Data for Radiation Transport Modeling}},
   doi         = {10.2172/1023125},
   url         = {https://www.osti.gov/biblio/1023125},
   annote      = {Introduction Meaningful simulations of radiation transport applications require realistic definitions of material composition and densities. When seeking that information for applications in fields such as homeland security, radiation shielding and protection, and criticality safety, researchers usually encounter a variety of materials for which elemental compositions are not readily available or densities are not defined. Publication of the Compendium of Material Composition Data for Radiation Transport Modeling, Revision 0, in 2006 was the first step toward mitigating this problem. Revision 0 of this document listed 121 materials, selected mostly from the combined personal libraries of staff at the Pacific Northwest National Laboratory (PNNL), and thus had a scope that was recognized at the time to be limited. Nevertheless, its creation did provide a well-referenced source of some unique or hard-to-define material data in a format that could be used directly in radiation transport calculations being performed at PNNL. Moreover, having a single common set of material definitions also helped to standardize at least one aspect of the various modeling efforts across the laboratory by providing separate researchers the ability to compare different model results using a common basis of materials. The authors of the 2006 compendium understood that, depending on its use and feedback, the compendium would need to be revised to correct errors or inconsistencies in the data for the original 121 materials, as well as to increase (per users suggestions) the number of materials listed. This 2010 revision of the compendium has accomplished both of those objectives. The most obvious change is the increased number of materials from 121 to 372. The not-so-obvious change is the mechanism used to produce the data listed here. The data listed in the 2006 document were compiled, evaluated, entered, and error-checked by a group of individuals essentially by hand, providing no library file or mechanism for revising the data in a consistent and traceable manner. The authors of this revision have addressed that problem by first compiling all of the information (i.e., numbers and references) for all the materials into a single database, maintained at PNNL, that was then used as the basis for this document.},
@@ -66,13 +66,13 @@
 }
 
 @article{MCPL_ref,
-title = {Monte Carlo Particle Lists: MCPL},
+title = {{Monte Carlo Particle Lists: MCPL}},
 journal = {Computer Physics Communications},
 volume = {218},
 pages = {17-42},
 year = {2017},
 issn = {0010-4655},
-doi = {https://doi.org/10.1016/j.cpc.2017.04.012},
+doi = {10.1016/j.cpc.2017.04.012},
 url = {https://www.sciencedirect.com/science/article/pii/S0010465517301261},
 author = {T. Kittelmann and E. Klinkby and E.B. Knudsen and P. Willendrup and X.X. Cai and K. Kanaki},
 keywords = {MCPL, Monte Carlo simulations, Particle storage, File format, Geant4, MCNP, McStas, McXtrace},
@@ -105,7 +105,7 @@ keywords = {MCPL, Monte Carlo simulations, Particle storage, File format, Geant4
 
 @article{Flair3_ref,
 	author = {{Donadon, André} and {Hugo, Gabrielle} and {Theis, Christian} and {Vlachoudis, Vasilis}},
-	title = {FLAIR3 – recasting simulation experiences with the Advanced Interface for FLUKA and other Monte Carlo codes},
+	title = {{FLAIR3 – recasting simulation experiences with the Advanced Interface for FLUKA and other Monte Carlo codes}},
 	DOI= "10.1051/epjconf/202430211005",
 	url= "https://doi.org/10.1051/epjconf/202430211005",
 	journal = {EPJ Web Conf.},
@@ -116,7 +116,7 @@ keywords = {MCPL, Monte Carlo simulations, Particle storage, File format, Geant4
 
 @article{Fluka2024_ref,
 	author = {{The FLUKA Collaboration} and {Ballarini, Francesca} and {Batkov, Konstantin} and {Battistoni, Giuseppe} and {Bisogni, Maria Giuseppina} and {Böhlen, Till T.} and {Campanella, Mauro} and {Carante, Mario P.} and {Chen, Daiyuan} and {De Gregorio, Angelica} and {Degtiarenko, Pavel V.} and {De la Torre Luque, Pedro} and {dos Santos Augusto, Ricardo} and {Engel, Ralph} and {Fassò, Alberto} and {Fedynitch, Anatoli} and {Ferrari, Alfredo} and {Ferrari, Anna} and {Franciosini, Gaia} and {Kraan, Aafke Christine} and {Lascaud, Julie} and {Li, Wenxin} and {Liu, Juntao} and {Liu, Zhiyi} and {Magro, Giuseppe} and {Mairani, Andrea} and {Mattei, Ilaria} and {Mazziotta, Mario N.} and {Morone, Maria C.} and {Müller, Stefan E.} and {Muraro, Silvia} and {Ortega, Pablo G.} and {Parodi, Katia} and {Patera, Vincenzo} and {Pinsky, Lawrence S.} and {Ramos, Ricardo L.} and {Ranft, Johannes} and {Rosso, Valeria} and {Sala, Paola R.} and {Santana Leitner, Mario} and {Sportelli, Giancarlo} and {Tessonnier, Thomas} and {Ytre-Hauge, Kristian S.} and {Zana, Lorenzo}},
-	title = {The FLUKA code: Overview and new developments},
+	title = {The {FLUKA} code: Overview and new developments},
 	DOI= "10.1051/epjn/2024015",
 	url= "https://doi.org/10.1051/epjn/2024015",
 	journal = {EPJ Nuclear Sci. Technol.},

--- a/paper.md
+++ b/paper.md
@@ -83,7 +83,7 @@ of the PHITS and DCHAIN codes and Python&mdash;greatly expediting further progra
 comparisons, and visualization&mdash;and provide some extra analysis tools. 
 The outputs of the PHITS code are, aside from the special binary "dump" files, plaintext files formatted 
 for processing by a custom visualization code (generating Encapsulated PostScript files) 
-shipped with and automatically ran by PHITS, and those of the DCHAIN 
+shipped with and automatically run by PHITS, and those of the DCHAIN
 code are formatted in a variety of tabular, human-readable structures.  
 
 Historically, programmatic extraction and organization of numerical results and 
@@ -91,9 +91,9 @@ metadata from both codes often required
 writing a bespoke processing script for most individual simulations, 
 possibly preceded by manual data extraction/isolation too. 
 PHITS Tools provides universal output parsers for the PHITS and DCHAIN codes, 
-capable of processing all of the relevant output files produced by each code and
-outputting the numerical results and metadata in a consistent, standardized output format, 
-also able to automatically make and save plots of tally results.
+capable of processing all of the relevant output files produced by each code,
+outputting the numerical results and metadata in a consistent, standardized output format, and
+also automatically making and saving plots of tally results.
 No similar comprehensive PHITS/DCHAIN output parsing utilities presently exist. 
 The MCPL: Monte Carlo Particle Lists [@MCPL_ref] package can parse 
 PHITS binary dump files if using one of two specific combinations of tally dump parameter settings, and 
@@ -136,14 +136,14 @@ preferring working with Pandas.
 +-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | 9 / `ierr`        | `= 0/1/2`, Value / relative uncertainty / absolute uncertainty *                                                                                             |
 +===================+==============================================================================================================================================================+
-| *exceptional behavior with [T-Cross] tally when `enclos = 0` is set; see [full documentation](https://lindt8.github.io/PHITS-Tools/#PHITS_tools.parse_tally_output_file)         |
+| *exceptional behavior with [T-Cross] tally when `enclos = 0` is set; see [full documentation](https://lindt8.github.io/PHITS-Tools/#PHITS_tools.parse_tally_output_file)*        |
 +===================+==============================================================================================================================================================+
 
 PHITS Tools is also capable of parsing the "dump" output files (both binary and plaintext formats) 
 that are available for some tallies, and it can also automatically detect, parse, and process all PHITS 
 output files listed in a provided directory or PHITS input file&mdash;very convenient 
 for simulations employing multiple tallies, each with its own output file, 
-whose output are to be further studied, e.g., compared to experimental data or other simulations. 
+whose outputs are to be further studied, e.g., compared to experimental data or other simulations.
 PHITS Tools can be used by:
 
 1. importing it as a Python package in a script and calling its functions, 


### PR DESCRIPTION
Fixes typos/capitalization in references, small grammar/phrasing changes, as detailed in JOSS review comment: https://github.com/openjournals/joss-reviews/issues/8311#issuecomment-3293664770